### PR TITLE
Add missing check for ownerNode in proxyDocumentStyleSheets

### DIFF
--- a/src/inject/dynamic-theme/stylesheet-proxy.ts
+++ b/src/inject/dynamic-theme/stylesheet-proxy.ts
@@ -99,7 +99,7 @@ export function injectProxy(enableStyleSheetsProxy: boolean) {
             const docSheets: StyleSheetList = documentStyleSheetsDescriptor!.get!.call(this);
 
             const filteredSheets = [...docSheets].filter((styleSheet) => {
-                return !(styleSheet.ownerNode as Element).classList.contains('darkreader');
+                return styleSheet.ownerNode && !(styleSheet.ownerNode as Element).classList.contains('darkreader');
             });
 
             (filteredSheets as unknown as StyleSheetList).item = (item: number) => {


### PR DESCRIPTION
There was one place where it wasn't checked if a stylesheet actually has an `ownerNode`. A check has been added. I've been observing JavaScript errors originating from the `proxyDocumentStyleSheets` function caused by trying to access the `classList` of an `ownerNode` that's `null`.